### PR TITLE
collapse template files in vscode explorer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,13 @@
   "editor.unicodeHighlight.allowedCharacters": {
     "꞉": true // used in CST snapshot tests
   },
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    // __JINJA_TEMPLATES_EXTENSIONS__ (keep in sync)
+    "*.generated.mts": "${capture}.mts.jinja2",
+    "*.generated.rs": "${capture}.rs.jinja2",
+    "*.generated.wit": "${capture}.wit.jinja2"
+  },
   "files.eol": "\n",
   "files.insertFinalNewline": true,
   "files.readonlyInclude": {

--- a/crates/infra/utils/src/codegen/runtime.rs
+++ b/crates/infra/utils/src/codegen/runtime.rs
@@ -45,6 +45,12 @@ impl CodegenRuntime {
         let template_path = template_path.with_extension("");
         let (base_name, extension) = template_path.unwrap_name().rsplit_once('.').unwrap();
 
+        assert!(matches!(
+            extension,
+            // __JINJA_TEMPLATES_EXTENSIONS__ (keep in sync)
+            "mts" | "rs" | "wit"
+        ));
+
         // remove the starting `_` if there is one (ir templates starts with this marker)
         let base_name = base_name.strip_prefix('_').unwrap_or(base_name);
 


### PR DESCRIPTION
collapse generated files under their templates in the vscode file explorer, to make it easier to work with template-heavy modules.